### PR TITLE
Upgrades to Ext.NET 7.4.0 + fix

### DIFF
--- a/Ext.Net.Examples.sln
+++ b/Ext.Net.Examples.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 16.0.29324.140
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ext.Net.Examples", "src\Ext.Net.Examples.csproj", "{1782FA9C-D6DA-4E90-A3C6-2A6C87615D43}"
 EndProject
-Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{354A8855-43FD-4CDD-9B7F-2745B799F6E0}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,10 +15,6 @@ Global
 		{1782FA9C-D6DA-4E90-A3C6-2A6C87615D43}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1782FA9C-D6DA-4E90-A3C6-2A6C87615D43}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1782FA9C-D6DA-4E90-A3C6-2A6C87615D43}.Release|Any CPU.Build.0 = Release|Any CPU
-		{354A8855-43FD-4CDD-9B7F-2745B799F6E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{354A8855-43FD-4CDD-9B7F-2745B799F6E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{354A8855-43FD-4CDD-9B7F-2745B799F6E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{354A8855-43FD-4CDD-9B7F-2745B799F6E0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Ext.Net.Examples.csproj
+++ b/src/Ext.Net.Examples.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ext.NET.Classic" Version="7.3.0" />
-    <PackageReference Include="Ext.NET.Classic.Charts" Version="7.3.0" />
+    <PackageReference Include="Ext.NET.Classic" Version="7.4.0" />
+    <PackageReference Include="Ext.NET.Classic.Charts" Version="7.4.0" />
     <PackageReference Include="Mojee" Version="1.3.0" />
   </ItemGroup>
 

--- a/src/Pages/samples/buttons/basic/overview/index.cshtml
+++ b/src/Pages/samples/buttons/basic/overview/index.cshtml
@@ -169,11 +169,5 @@
         </h4>
 
         <ext-button text="128 x 128" height="128" width="128" />
-
-        <h4>
-            12. Hyperlink
-        </h4>
-
-        <ext-hyperlink text="Hyperlink" />
     </body>
 </html>


### PR DESCRIPTION
Upgrades references to Ext.NET 7.4 and removes a reference to a not implemented ext-hyperlink component from the Button Overview example.